### PR TITLE
fix: different paths for env script and migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -29,7 +29,7 @@ script_location = app/models/orm/migrations
 # version location specification; this defaults
 # to app/models/orm/alembic/versions.  When using multiple version
 # directories, initial revisions must be specified with --version-path
-version_locations = app/models/orm/migrations
+version_locations = app/models/orm/migrations/versions
 
 # the output encoding used when revision files
 # are written from script.py.mako


### PR DESCRIPTION
With both of these on the same path alembic causes a deadlock condition trying to create the `alembic_version` table for the first time.

When I inspected the call path (by pdbing `_ensure_version_table`), I saw the second call to create the table that happened during the same (first) transaction, originated from the `get_revisions` call path. Not sure how this could ever work for someone else.

```
(Pdb) w
  venv/bin/alembic(8)<module>()
-> sys.exit(main())
  venv/lib/python3.8/site-packages/alembic/config.py(577)main()
-> CommandLine(prog=prog).main(argv=argv)
  venv/lib/python3.8/site-packages/alembic/config.py(571)main()
-> self.run_cmd(cfg, options)
  venv/lib/python3.8/site-packages/alembic/config.py(548)run_cmd()
-> fn(
  venv/lib/python3.8/site-packages/alembic/command.py(214)revision()
-> script_directory.run_env()
  venv/lib/python3.8/site-packages/alembic/script/base.py(489)run_env()
-> util.load_python_file(self.dir, "env.py")
  venv/lib/python3.8/site-packages/alembic/util/pyfiles.py(98)load_python_file()
-> module = load_module_py(module_id, path)
  venv/lib/python3.8/site-packages/alembic/util/compat.py(184)load_module_py()
-> spec.loader.exec_module(module)
  <frozen importlib._bootstrap_external>(783)exec_module()
  <frozen importlib._bootstrap>(219)_call_with_frames_removed()
  london-looker/app/models/orm/migrations/env.py(78)<module>()
-> run_migrations_online()
  london-looker/app/models/orm/migrations/env.py(72)run_migrations_online()
-> context.run_migrations()
  <string>(8)run_migrations()
  venv/lib/python3.8/site-packages/alembic/runtime/environment.py(846)run_migrations()
-> self.get_context().run_migrations(**kw)
  venv/lib/python3.8/site-packages/alembic/runtime/migration.py(510)run_migrations()
-> for step in self._migrations_fn(heads, self):
  venv/lib/python3.8/site-packages/alembic/command.py(190)retrieve_migrations()
-> revision_context.run_autogenerate(rev, context)
  venv/lib/python3.8/site-packages/alembic/autogenerate/api.py(442)run_autogenerate()
-> self._run_environment(rev, migration_context, True)
  venv/lib/python3.8/site-packages/alembic/autogenerate/api.py(454)_run_environment()
-> self.script_directory.get_revisions("heads")
  venv/lib/python3.8/site-packages/alembic/script/base.py(227)get_revisions()
-> return self.revision_map.get_revisions(id_)
  venv/lib/python3.8/site-packages/alembic/script/revision.py(321)get_revisions()
-> resolved_id, branch_label = self._resolve_revision_number(id_)
  venv/lib/python3.8/site-packages/alembic/script/revision.py(501)_resolve_revision_number()
-> self._revision_map
  venv/lib/python3.8/site-packages/alembic/util/langhelpers.py(230)__get__()
-> obj.__dict__[self.__name__] = result = self.fget(obj)
  venv/lib/python3.8/site-packages/alembic/script/revision.py(123)_revision_map()
-> for revision in self._generator():
  venv/lib/python3.8/site-packages/alembic/script/base.py(112)_load_revisions()
-> script = Script._from_filename(self, vers, file_)
  venv/lib/python3.8/site-packages/alembic/script/base.py(906)_from_filename()
-> module = util.load_python_file(dir_, filename)
  venv/lib/python3.8/site-packages/alembic/util/pyfiles.py(98)load_python_file()
-> module = load_module_py(module_id, path)
  venv/lib/python3.8/site-packages/alembic/util/compat.py(184)load_module_py()
-> spec.loader.exec_module(module)
  <frozen importlib._bootstrap_external>(783)exec_module()
  <frozen importlib._bootstrap>(219)_call_with_frames_removed()
  london-looker/app/models/orm/migrations/env.py(78)<module>()
-> run_migrations_online()
  london-looker/app/models/orm/migrations/env.py(72)run_migrations_online()
-> context.run_migrations()
  <string>(8)run_migrations()
  venv/lib/python3.8/site-packages/alembic/runtime/environment.py(846)run_migrations()
-> self.get_context().run_migrations(**kw)
  venv/lib/python3.8/site-packages/alembic/runtime/migration.py(502)run_migrations()
-> self._ensure_version_table()
> venv/lib/python3.8/site-packages/alembic/runtime/migration.py(443)_ensure_version_table()
-> self._version.create(self.connection, checkfirst=True)
```